### PR TITLE
Porting zclp++ server, client and frames to zclp-rs

### DIFF
--- a/src/zclp.rs
+++ b/src/zclp.rs
@@ -6,6 +6,14 @@ struct VariableLengthInteger {
     value: Vec<u8>, // ((2^Len)*8)-2 bits
 }
 
+impl VariableLengthInteger {
+    pub fn new() {
+        Self { len: 0, value: 0 }
+    }
+
+    pub fn set(&mut self, value: u64) {}
+}
+
 #[allow(dead_code)]
 mod frames {
     use super::VariableLengthInteger;


### PR DESCRIPTION
Started to implementing missing functionality in zclp-rs, which is already present in zclp++